### PR TITLE
IOS-1422 - Expose via Alfresco Auth module API that returns the available login methods for a given identity service URL

### DIFF
--- a/AlfrescoAuth/AlfrescoAuth.podspec
+++ b/AlfrescoAuth/AlfrescoAuth.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
 s.name                  = 'AlfrescoAuth'
-s.version               = '0.2.1'
+s.version               = '0.3.0'
 s.summary               = 'Alfresco DBP SDK Auth module'
 s.homepage              = 'http://alfresco-identity-service.mobile.dev.alfresco.me'
 # 'https://github.com/Alfresco/ios-dbp-sdk'

--- a/AlfrescoAuth/AlfrescoAuth.xcodeproj/project.pbxproj
+++ b/AlfrescoAuth/AlfrescoAuth.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		2BE0E70422F84EAB002857F0 /* TestData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BE0E70322F84EAB002857F0 /* TestData.swift */; };
 		2BE921A8230C26DF0009F470 /* String+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BE921A7230C26DF0009F470 /* String+Helpers.swift */; };
 		B95789F12344971B00F19594 /* AuthPkcePresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B95789F02344971B00F19594 /* AuthPkcePresenter.swift */; };
+		B96C65E02369DA03004E1402 /* HeadProcessServiceDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = B96C65DF2369DA03004E1402 /* HeadProcessServiceDocument.swift */; };
 		B98D87DB2344D47000BC0259 /* AlfrescoAuthSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = B98D87DA2344D47000BC0259 /* AlfrescoAuthSession.swift */; };
 		E31B47E122F97C53002B6BC5 /* AuthWebViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E31B47E022F97C53002B6BC5 /* AuthWebViewControllerTests.swift */; };
 		E31FE3432355B5CE0024B376 /* AlfrescoAuthDelegateStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = E31FE3422355B5CE0024B376 /* AlfrescoAuthDelegateStub.swift */; };
@@ -72,6 +73,7 @@
 		2BE0E70322F84EAB002857F0 /* TestData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestData.swift; sourceTree = "<group>"; };
 		2BE921A7230C26DF0009F470 /* String+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Helpers.swift"; sourceTree = "<group>"; };
 		B95789F02344971B00F19594 /* AuthPkcePresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthPkcePresenter.swift; sourceTree = "<group>"; };
+		B96C65DF2369DA03004E1402 /* HeadProcessServiceDocument.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeadProcessServiceDocument.swift; sourceTree = "<group>"; };
 		B98D87DA2344D47000BC0259 /* AlfrescoAuthSession.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AlfrescoAuthSession.swift; sourceTree = "<group>"; };
 		E31B47DF22F97844002B6BC5 /* AlfrescoAuth.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = AlfrescoAuth.xctestplan; sourceTree = "<group>"; };
 		E31B47E022F97C53002B6BC5 /* AuthWebViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthWebViewControllerTests.swift; sourceTree = "<group>"; };
@@ -170,6 +172,7 @@
 		2BE0E70522F965A2002857F0 /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				B96C65DF2369DA03004E1402 /* HeadProcessServiceDocument.swift */,
 				E3C38EF42327B4EA007FCF8B /* GetAlfrescoCredential.swift */,
 				2BD6E16C22F47FFE00949E44 /* AlfrescoCredential.swift */,
 				E3267D4423420E4C00ED429C /* AuthConfiguration.swift */,
@@ -407,6 +410,7 @@
 				E3DB7767233A296A000122BB /* AuthWebViewController.swift in Sources */,
 				B95789F12344971B00F19594 /* AuthPkcePresenter.swift in Sources */,
 				2BD6E16922F4699000949E44 /* AuthWebPresenter.swift in Sources */,
+				B96C65E02369DA03004E1402 /* HeadProcessServiceDocument.swift in Sources */,
 				2BD6E16322F4475700949E44 /* Constants.swift in Sources */,
 				2BD6E16D22F47FFE00949E44 /* AlfrescoCredential.swift in Sources */,
 				E3C38EF52327B4EA007FCF8B /* GetAlfrescoCredential.swift in Sources */,

--- a/AlfrescoAuth/AlfrescoAuthTests/Mocks/APIClientStub.swift
+++ b/AlfrescoAuth/AlfrescoAuthTests/Mocks/APIClientStub.swift
@@ -14,7 +14,7 @@ class APIClientStub: APIClientProtocol {
     var baseURL: URL?
     var successResponse: Bool = true
     
-    required init(with base: String) {
+    required init(with base: String, session: URLSessionProtocol) {
         self.baseURL = URL(string: base)
     }
     

--- a/AlfrescoAuth/AlfrescoAuthTests/Presenters Tests/AuthBasicPresenterTests.swift
+++ b/AlfrescoAuth/AlfrescoAuthTests/Presenters Tests/AuthBasicPresenterTests.swift
@@ -38,7 +38,7 @@ class AuthBasicPresenterTests: XCTestCase {
     
     func testExecuteWithSuccess() {
         let delegateStub = AlfrescoAuthDelegateStub()
-        let apiClientSub = APIClientStub(with: TestData.baseUrlGood)
+        let apiClientSub = APIClientStub(with: TestData.baseUrlGood, session: URLSession(configuration: .default))
         
         apiClientSub.successResponse = true
         delegateStub.expectationForDidRevicedCall = expectationForDidRevicedCall
@@ -53,7 +53,7 @@ class AuthBasicPresenterTests: XCTestCase {
     
     func testExecuteWithFailure() {
         let delegateStub = AlfrescoAuthDelegateStub()
-        let apiClientSub = APIClientStub(with: TestData.baseUrlGood)
+        let apiClientSub = APIClientStub(with: TestData.baseUrlGood, session: URLSession(configuration: .default))
         
         apiClientSub.successResponse = false
         delegateStub.expectationForDidRevicedCall = expectationForDidRevicedCall
@@ -67,7 +67,7 @@ class AuthBasicPresenterTests: XCTestCase {
     }
     
     func testRequestTokenWithSuccess() {
-        let apiClientSub = APIClientStub(with: TestData.baseUrlGood)
+        let apiClientSub = APIClientStub(with: TestData.baseUrlGood, session: URLSession(configuration: .default))
         apiClientSub.successResponse = true
         sut.apiClient = apiClientSub
         sut.requestToken(with: TestData.username1, and: TestData.password1, completion: { (result) in
@@ -83,7 +83,7 @@ class AuthBasicPresenterTests: XCTestCase {
     }
     
     func testRequestTokenWithFailure() {
-        let apiClientSub = APIClientStub(with: TestData.baseUrlGood)
+        let apiClientSub = APIClientStub(with: TestData.baseUrlGood, session: URLSession(configuration: .default))
         apiClientSub.successResponse = false
         sut.apiClient = apiClientSub
         sut.requestToken(with: TestData.username1, and: TestData.password2, completion: { (result) in

--- a/AlfrescoAuth/AlfrescoAuthTests/Presenters Tests/AuthWebPresenterTests.swift
+++ b/AlfrescoAuth/AlfrescoAuthTests/Presenters Tests/AuthWebPresenterTests.swift
@@ -40,7 +40,7 @@ class AuthWebPresenterTests: XCTestCase {
     }
     
     func testSutParseReturnWKNavigationActionPolicyCancel() {
-        let apiClientSub = APIClientStub(with: TestData.baseUrlGood)
+        let apiClientSub = APIClientStub(with: TestData.baseUrlGood, session: URLSession(configuration: .default))
         sut.apiClient = apiClientSub
         navigationActionStub.sendCodeUrl = true
         
@@ -55,7 +55,7 @@ class AuthWebPresenterTests: XCTestCase {
     }
     
     func testSutParseCallsWithSuccess() {
-        let apiClientSub = APIClientStub(with: TestData.baseUrlGood)
+        let apiClientSub = APIClientStub(with: TestData.baseUrlGood, session: URLSession(configuration: .default))
         let delegateStub = AlfrescoAuthDelegateStub()
         
         delegateStub.expectationForDidRevicedCall = expectationForDidRevicedCall
@@ -70,7 +70,7 @@ class AuthWebPresenterTests: XCTestCase {
     }
     
     func testSutParseCallsWithFailure() {
-        let apiClientSub = APIClientStub(with: TestData.baseUrlGood)
+        let apiClientSub = APIClientStub(with: TestData.baseUrlGood, session: URLSession(configuration: .default))
         let delegateStub = AlfrescoAuthDelegateStub()
         
         delegateStub.expectationForDidRevicedCall = expectationForDidRevicedCall
@@ -85,7 +85,7 @@ class AuthWebPresenterTests: XCTestCase {
     }
     
     func testRequestTokenWithSuccess() {
-        let apiClientSub = APIClientStub(with: TestData.baseUrlGood)
+        let apiClientSub = APIClientStub(with: TestData.baseUrlGood, session: URLSession(configuration: .default))
         apiClientSub.successResponse = true
         sut.apiClient = apiClientSub
         sut.requestToken(with: TestData.codeGood) { (result) in
@@ -101,7 +101,7 @@ class AuthWebPresenterTests: XCTestCase {
     }
     
     func testRequestTokenWithFailure() {
-        let apiClientSub = APIClientStub(with: TestData.baseUrlGood)
+        let apiClientSub = APIClientStub(with: TestData.baseUrlGood, session: URLSession(configuration: .default))
         apiClientSub.successResponse = false
         sut.apiClient = apiClientSub
         sut.requestToken(with: TestData.codeGood) { (result) in

--- a/AlfrescoAuth/AlfrescoAuthTests/Presenters Tests/RefreshTokenPresenterTests.swift
+++ b/AlfrescoAuth/AlfrescoAuthTests/Presenters Tests/RefreshTokenPresenterTests.swift
@@ -39,7 +39,7 @@ class RefreshTokenPresenterTests: XCTestCase {
     func testExecuteRefreshWithSuccess() {
         let alfrescoCredential = AlfrescoCredential(with: TestData.dictionaryAlfrescoCredentialGood)
         let delegateStub = AlfrescoAuthDelegateStub()
-        let apiClientSub = APIClientStub(with: TestData.baseUrlGood)
+        let apiClientSub = APIClientStub(with: TestData.baseUrlGood, session: URLSession(configuration: .default))
         
         apiClientSub.successResponse = true
         delegateStub.expectationForDidRevicedCall = expectationForDidRevicedCall
@@ -55,7 +55,7 @@ class RefreshTokenPresenterTests: XCTestCase {
     func testExecuteRefreshWithFailure() {
         let alfrescoCredential = AlfrescoCredential(with: TestData.dictionaryAlfrescoCredentialGood)
         let delegateStub = AlfrescoAuthDelegateStub()
-        let apiClientSub = APIClientStub(with: TestData.baseUrlGood)
+        let apiClientSub = APIClientStub(with: TestData.baseUrlGood, session: URLSession(configuration: .default))
         
         apiClientSub.successResponse = false
         delegateStub.expectationForDidRevicedCall = expectationForDidRevicedCall
@@ -70,7 +70,7 @@ class RefreshTokenPresenterTests: XCTestCase {
     
     func testRequestTokenWithSuccess() {
         let alfrescoCredential = AlfrescoCredential(with: TestData.dictionaryAlfrescoCredentialGood)
-        let apiClientSub = APIClientStub(with: TestData.baseUrlGood)
+        let apiClientSub = APIClientStub(with: TestData.baseUrlGood, session: URLSession(configuration: .default))
         apiClientSub.successResponse = true
         sut.apiClient = apiClientSub
         sut.requestToken(with: alfrescoCredential) { (result) in
@@ -87,7 +87,7 @@ class RefreshTokenPresenterTests: XCTestCase {
     
     func testRequestTokenWithFailure() {
         let alfrescoCredential = AlfrescoCredential(with: TestData.dictionaryAlfrescoCredentialGood)
-        let apiClientSub = APIClientStub(with: TestData.baseUrlGood)
+        let apiClientSub = APIClientStub(with: TestData.baseUrlGood, session: URLSession(configuration: .default))
         apiClientSub.successResponse = false
         sut.apiClient = apiClientSub
         sut.requestToken(with: alfrescoCredential) { (result) in

--- a/AlfrescoAuth/Podfile.lock
+++ b/AlfrescoAuth/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - AlfrescoCore (0.1.2)
+  - AlfrescoCore (0.2.0)
   - AppAuth (1.2.0):
     - AppAuth/Core (= 1.2.0)
     - AppAuth/ExternalUserAgent (= 1.2.0)
@@ -11,15 +11,15 @@ DEPENDENCIES:
   - AppAuth
 
 SPEC REPOS:
-  https://github.com/Alfresco/alfresco-private-podspecs-ios-sdk.git:
+  https://github.com/Alfresco/alfresco-private-podspecs-ios-sdk:
     - AlfrescoCore
   https://github.com/CocoaPods/Specs.git:
     - AppAuth
 
 SPEC CHECKSUMS:
-  AlfrescoCore: 8f2503b2f2b26712278953db92b7c15730266db3
+  AlfrescoCore: ab6c6563687127d693230c85ae11f06f02991733
   AppAuth: bce82c76043657c99d91e7882e8a9e1a93650cd4
 
-PODFILE CHECKSUM: b6e1ff011e1885ec8f3230b6787ccf6f64f88701
+PODFILE CHECKSUM: ee8029c35ac981562be8cb81d91ea5a79299318f
 
-COCOAPODS: 1.8.0
+COCOAPODS: 1.8.4

--- a/AlfrescoAuth/Sources/AlfrescoAuth.swift
+++ b/AlfrescoAuth/Sources/AlfrescoAuth.swift
@@ -94,6 +94,18 @@ public struct AlfrescoAuth {
         return authSession
     }
     
+    /** Given a path component,  it returns via a closure the available authentication type for the base URL defined in the AlfrescoConfiguration
+     object and the defined path. If the path is not defined, then only the base URL will be used as reference.
+     - Parameter serviceDocument: service path for which the authentication type check is performed
+     - Parameter handler: Closure delivering updates on the authentication type. Possible values are base auth, AIMS and an optional error
+     */
+    public mutating func availableAuthType(for serviceDocument: String = "", handler:@escaping ((Result<AvailableAuthType, APIError>) -> Void)) {
+        pkcePresenter = AuthPkcePresenter(configuration: configuration)
+        pkcePresenter?.availableAuthType(for: serviceDocument, handler: { result in
+            handler(result)
+        })
+    }
+    
     /** Designated safe session refresh method with Identity Service  using PKCE protocol.
     - Parameter alfrescoAuthDelegate: Delegate used to report the state and response of the re-authentication request
     */

--- a/AlfrescoAuth/Sources/Model/HeadProcessServiceDocument.swift
+++ b/AlfrescoAuth/Sources/Model/HeadProcessServiceDocument.swift
@@ -1,0 +1,37 @@
+//
+//  GetProcessServiceDocument.swift
+//  AlfrescoAuth
+//
+//  Created by Emanuel Lupu on 30/10/2019.
+//  Copyright © 2019 Alfresco. All rights reserved.
+//
+
+import Foundation
+import AlfrescoCore
+
+
+struct HeadServiceDocumentInstance: APIRequest {
+    typealias Response = StatusCodeResponse
+    
+    let serviceDocumentInstanceURL: String
+    
+    var path: String {
+        return serviceDocumentInstanceURL
+    }
+    
+    var method: HttpMethod {
+        return .head
+    }
+    
+    var headers: [String : ContentType] {
+        return [:]
+    }
+    
+    var parameters: [String : String] {
+        return [:]
+    }
+
+    init(serviceDocumentInstanceURL: String) {
+        self.serviceDocumentInstanceURL = serviceDocumentInstanceURL
+    }
+}


### PR DESCRIPTION
- extended Auth module interface to include method for checking available authentication mechanism for the baseURL and a service document path
- Updated podspec file