### PR TITLE
IOS-1449 - The sign in on premise cannot be done if the server is not responding to HEAD request

### DIFF
--- a/AlfrescoCore/AlfrescoCore.podspec
+++ b/AlfrescoCore/AlfrescoCore.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
 s.name                  = 'AlfrescoCore'
-s.version               = '0.2.4'
+s.version               = '0.2.5'
 s.summary               = 'Alfresco DBP SDK Core module'
 s.homepage              = 'http://alfresco-identity-service.mobile.dev.alfresco.me'
 # 'https://github.com/Alfresco/ios-dbp-sdk'

--- a/AlfrescoCore/Sources/Network/APIClient.swift
+++ b/AlfrescoCore/Sources/Network/APIClient.swift
@@ -69,7 +69,7 @@ public class APIClient: APIClientProtocol {
                     return
                 }
                 
-                if (data.isEmpty) {
+                if (T.Response.self == StatusCodeResponse.self) {
                     completion(.success(sSelf.statusCodeResponse(T.Response.self, responseCode: response.statusCode)))
                 } else {
                     do {


### PR DESCRIPTION
- adjusted APIClient to isolate StatusCodeResponse types for API requests