### PR TITLE
MOBILEAPPS-295 - Implement basic auth screen

### DIFF
--- a/AlfrescoCore/AlfrescoCore.podspec
+++ b/AlfrescoCore/AlfrescoCore.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
 s.name                  = 'AlfrescoCore'
-s.version               = '2.0.0'
+s.version               = '2.0.1'
 s.summary               = 'Alfresco DBP SDK Core module'
 s.homepage              = 'http://alfresco-identity-service.mobile.dev.alfresco.me'
 # 'https://github.com/Alfresco/ios-dbp-sdk'

--- a/AlfrescoCore/Sources/Network/APIClient.swift
+++ b/AlfrescoCore/Sources/Network/APIClient.swift
@@ -98,7 +98,7 @@ public class APIClient: APIClientProtocol {
             urlRequest?.httpMethod = request.method.rawValue
             
             for (key, value) in request.headers {
-                urlRequest?.setValue(value.rawValue, forHTTPHeaderField: key)
+                urlRequest?.setValue(value, forHTTPHeaderField: key)
             }
             
             switch request.method {

--- a/AlfrescoCore/Sources/Network/APIRequest.swift
+++ b/AlfrescoCore/Sources/Network/APIRequest.swift
@@ -36,7 +36,7 @@ public protocol APIRequest: Encodable {
     // HTTP verb of the request
     var method: HttpMethod { get }
     // Request header parameters
-    var headers: [String: ContentType] { get }
+    var headers: [String: String] { get }
     // Additional request parameters
     var parameters: [String: String] { get }
 }


### PR DESCRIPTION
- removed content type constraint on request header type to allow arbitrary values to be as input